### PR TITLE
Duplicated BuildHistory

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/mtslavescloud/BillingMemoBuilder.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/mtslavescloud/BillingMemoBuilder.java
@@ -52,9 +52,8 @@ public class BillingMemoBuilder extends RunListener<AbstractBuild> {
 
     @Override
     public void onFinalized(AbstractBuild run) {
-        if (run.getBuiltOn() != null && run.getBuiltOn() instanceof MansionSlave) {
-            AbstractBuild build = (AbstractBuild) run;
-            Node node = build.getBuiltOn();
+        Node node = run.getBuiltOn();
+        if (node instanceof MansionSlave) {
             BuildHistory history = node.getNodeProperties().get(BuildHistory.class);
             if (history == null) {
                 history = new BuildHistory();


### PR DESCRIPTION
Found in a `$JENKINS_HOME/config.xml`:

```
  <nodeProperties>
    <com.cloudbees.jenkins.plugins.mtslavescloud.BillingMemoBuilder_-BuildHistory plugin="mansion-cloud@1.22">
      <builds>
        …
      </builds>
    </com.cloudbees.jenkins.plugins.mtslavescloud.BillingMemoBuilder_-BuildHistory>
    <com.cloudbees.jenkins.plugins.mtslavescloud.BillingMemoBuilder_-BuildHistory reference="../com.cloudbees.jenkins.plugins.mtslavescloud.BillingMemoBuilder_-BuildHistory"/>
  </nodeProperties>
```
