### PR TITLE
Dedicated NodeProvisioner for mansion slaves

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,26 +48,6 @@
   </scm>
 
   <dependencies>
-    <dependency><!-- work around JENKINS-13754 -->
-      <groupId>org.kohsuke.stapler</groupId>
-      <artifactId>stapler</artifactId>
-      <version>1.213</version>
-      <scope>provided</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.kohsuke.stapler</groupId>
-          <artifactId>json-lib</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.google.guava</groupId>
-          <artifactId>guava</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>commons-io</groupId>
-          <artifactId>commons-io</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>ssh-slaves</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.580</version>
+    <version>1.609</version>
   </parent>
 
   <groupId>com.cloudbees.jenkins.plugins</groupId>

--- a/src/main/java/com/cloudbees/jenkins/plugins/mtslavescloud/MansionNodeProvisionerStrategy.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/mtslavescloud/MansionNodeProvisionerStrategy.java
@@ -129,25 +129,17 @@ public class MansionNodeProvisionerStrategy extends NodeProvisioner.Strategy {
             Collection<NodeProvisioner.PlannedNode> plannedNodes = mansionCloud.provision(label, currentDemand - availableCapacity);
             LOGGER.log(Level.FINE, "Planned {0} new nodes", plannedNodes.size());
             strategyState.recordPendingLaunches(plannedNodes);
+            availableCapacity += plannedNodes.size();
+            LOGGER.log(Level.FINE, "After provisioning, available capacity={0}, currentDemand={1}",
+                    new Object[]{availableCapacity, currentDemand});
         }
-        if (availableCapacity < currentDemand) {
-            return NodeProvisioner.StrategyDecision.CONSULT_REMAINING_STRATEGIES;
-        } else {
-            suggestReviewNow(label);
+        if (availableCapacity >= currentDemand) {
+            LOGGER.log(Level.FINE, "Provisioning completed");
             return NodeProvisioner.StrategyDecision.PROVISIONING_COMPLETED;
+        } else {
+            LOGGER.log(Level.FINE, "Provisioning not complete, consulting remaining strategies");
+            return NodeProvisioner.StrategyDecision.CONSULT_REMAINING_STRATEGIES;
         }
-    }
-
-    public static void suggestReviewNow(Label label) {
-        final Jenkins jenkins = Jenkins.getInstance();
-        if (jenkins == null) {
-            return;
-        }
-        final NodeProvisioner nodeProvisioner = (label == null)
-                ? jenkins.unlabeledNodeProvisioner
-                : label.nodeProvisioner;
-
-        nodeProvisioner.suggestReviewNow();
     }
 
     /**

--- a/src/main/java/com/cloudbees/jenkins/plugins/mtslavescloud/MansionNodeProvisionerStrategy.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/mtslavescloud/MansionNodeProvisionerStrategy.java
@@ -1,0 +1,172 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2016 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.cloudbees.jenkins.plugins.mtslavescloud;
+
+import com.cloudbees.jenkins.plugins.mtslavescloud.templates.SlaveTemplate;
+import com.cloudbees.jenkins.plugins.mtslavescloud.templates.SlaveTemplateList;
+import com.cloudbees.mtslaves.client.HardwareSpec;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import hudson.Extension;
+import hudson.ExtensionList;
+import hudson.model.Label;
+import hudson.model.LoadStatistics;
+import hudson.slaves.Cloud;
+import hudson.slaves.NodeProvisioner;
+import jenkins.model.Jenkins;
+
+import javax.annotation.Nonnull;
+import java.util.Collection;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Bypass the default NodeProvisioner to create slave as soon as a build start. This
+ * removes the need to hack hudson.model.LoadStatistics.clock property to have slaves in a resonable time.
+ */
+@Extension
+public class MansionNodeProvisionerStrategy extends NodeProvisioner.Strategy {
+    private static final Logger LOGGER = Logger.getLogger(MansionNodeProvisionerStrategy.class.getName());
+
+    private volatile boolean enabled =
+            Boolean.parseBoolean(
+                    System.getProperty(MansionNodeProvisionerStrategy.class.getName()+".enabled", "true")
+            );
+
+    /**
+     * Returns the strategy singleton for the current Jenkins instance.
+     *
+     * @return the strategy singleton for the current Jenkins instance or {@code null}
+     */
+    @CheckForNull
+    public static MansionNodeProvisionerStrategy getInstance() {
+        return ExtensionList.lookup(NodeProvisioner.Strategy.class).get(MansionNodeProvisionerStrategy.class);
+    }
+
+    /**
+     * Returns {@code true} if this strategy is enabled for the current Jenkins instance.
+     *
+     * @return {@code true} if this strategy is enabled for the current Jenkins instance.
+     */
+    public static boolean isEnabled() {
+        MansionNodeProvisionerStrategy strategy = getInstance();
+        return strategy != null && strategy.enabled;
+    }
+
+    /**
+     * Sets whether this strategy is enabled for the current Jenkins instance. Useful to disable this strategy
+     * in groovy console
+     *
+     * @param enabled if {@code true} then the strategy will be enabled - including injecting it in the list of
+     *                strategies if necessary, if {@code false} then the strategy will be disabled.
+     */
+    public static void setEnabled(boolean enabled) {
+        MansionNodeProvisionerStrategy strategy = getInstance();
+        if (strategy == null && enabled) {
+            strategy = new MansionNodeProvisionerStrategy();
+            ExtensionList.lookup(NodeProvisioner.Strategy.class).add(0, strategy);
+        }
+        if (strategy != null) {
+            strategy.enabled = enabled;
+        }
+    }
+
+    @Nonnull
+    @Override
+    public NodeProvisioner.StrategyDecision apply(@Nonnull NodeProvisioner.StrategyState strategyState) {
+        final Label label = strategyState.getLabel();
+
+        final SlaveTemplate st = SlaveTemplateList.get().get(label);
+        if (st == null) {
+            return NodeProvisioner.StrategyDecision.CONSULT_REMAINING_STRATEGIES;
+        }
+        if (!st.isEnabled()) {
+            LOGGER.log(Level.FINE, "Slave template is disabled {0}", st);
+            return NodeProvisioner.StrategyDecision.CONSULT_REMAINING_STRATEGIES;
+        }
+
+        final MansionCloud mansionCloud = getCloudImpl();
+        if (mansionCloud == null) {
+            return NodeProvisioner.StrategyDecision.CONSULT_REMAINING_STRATEGIES;
+        }
+        if (mansionCloud.getBackOffCounter(st).isBackOffInEffect()) {
+            LOGGER.log(Level.FINE, "Back off in effect for {0}", st);
+            return NodeProvisioner.StrategyDecision.CONSULT_REMAINING_STRATEGIES;
+        }
+        final HardwareSpec box = mansionCloud.getBoxOf(st, label);
+        if (mansionCloud.getQuotaProblems().isBlocked(box, st)) {
+            LOGGER.log(Level.FINE, "Provisioning of {0} blocked by quota problems.", st);
+            return NodeProvisioner.StrategyDecision.CONSULT_REMAINING_STRATEGIES;
+        }
+        LoadStatistics.LoadStatisticsSnapshot snapshot = strategyState.getSnapshot();
+        int availableCapacity = snapshot.getAvailableExecutors() + snapshot.getConnectingExecutors() +
+                strategyState.getAdditionalPlannedCapacity();
+        int currentDemand = snapshot.getQueueLength();
+        LOGGER.log(Level.FINE, "Available capacity={0}, currentDemand={1}",
+                new Object[]{availableCapacity, currentDemand});
+        if (availableCapacity < currentDemand) {
+            Collection<NodeProvisioner.PlannedNode> plannedNodes = mansionCloud.provision(label, currentDemand - availableCapacity);
+            LOGGER.log(Level.FINE, "Planned {0} new nodes", plannedNodes.size());
+            strategyState.recordPendingLaunches(plannedNodes);
+        }
+        if (availableCapacity < currentDemand) {
+            return NodeProvisioner.StrategyDecision.CONSULT_REMAINING_STRATEGIES;
+        } else {
+            suggestReviewNow(label);
+            return NodeProvisioner.StrategyDecision.PROVISIONING_COMPLETED;
+        }
+    }
+
+    public static void suggestReviewNow(Label label) {
+        final Jenkins jenkins = Jenkins.getInstance();
+        if (jenkins == null) {
+            return;
+        }
+        final NodeProvisioner nodeProvisioner = (label == null)
+                ? jenkins.unlabeledNodeProvisioner
+                : label.nodeProvisioner;
+
+        nodeProvisioner.suggestReviewNow();
+    }
+
+    /**
+     * Gets the {@link MansionCloud} instance.
+     * @return the {@link MansionCloud} instance or {@code null}.
+     */
+    @CheckForNull
+    private static MansionCloud getCloudImpl() {
+        final Jenkins jenkins = Jenkins.getInstance();
+        if (jenkins == null) {
+            return null;
+        }
+        MansionCloud mansionCloud = null;
+        for (Cloud cloud : jenkins.clouds) {
+            if (cloud instanceof MansionCloud) {
+                mansionCloud = (MansionCloud) cloud;
+                break;
+            }
+        }
+        return mansionCloud;
+    }
+}

--- a/src/main/java/com/cloudbees/jenkins/plugins/mtslavescloud/PlannedMansionSlaveSet.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/mtslavescloud/PlannedMansionSlaveSet.java
@@ -47,6 +47,19 @@ public class PlannedMansionSlaveSet implements Iterable<PlannedMansionSlave> {
     }
 
     /**
+     * @return the number of mansion slaves that are currently provisioned
+     */
+    public int getInProvisioningCount() {
+        int result = 0;
+        for (PlannedMansionSlave s : data) {
+            if (s.getProblem() == null) {
+                result++;
+            }
+        }
+        return result;
+    }
+
+    /**
      * Trim the content to remove uninteresting entries.
      *
      * Called by {@link PlannedMansionSlave} when there's a status change.

--- a/src/main/resources/com/cloudbees/jenkins/plugins/mtslavescloud/MansionSlave/configure-entries.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/mtslavescloud/MansionSlave/configure-entries.jelly
@@ -22,4 +22,5 @@
   ~ THE SOFTWARE.
   -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" />

--- a/src/main/resources/com/cloudbees/jenkins/plugins/mtslavescloud/templates/BuiltinSlaveTemplate/configure-common.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/mtslavescloud/templates/BuiltinSlaveTemplate/configure-common.jelly
@@ -22,6 +22,7 @@
   ~ THE SOFTWARE.
   -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <!-- nothing else to configure -->
 </j:jelly>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/mtslavescloud/templates/LocalSlaveTemplate/configure-common.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/mtslavescloud/templates/LocalSlaveTemplate/configure-common.jelly
@@ -22,6 +22,7 @@
   ~ THE SOFTWARE.
   -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <f:section title="Definition">
     <f:entry field="mansionType" title="${%Mansion Type}">

--- a/src/main/resources/com/cloudbees/jenkins/plugins/mtslavescloud/templates/LocalSlaveTemplate/newInstanceDetail.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/mtslavescloud/templates/LocalSlaveTemplate/newInstanceDetail.jelly
@@ -22,6 +22,7 @@
   ~ THE SOFTWARE.
   -->
 
+<?jelly escape-by-default='true'?>
 <div>
   Define a slave template locally on this computer for use as build slaves on this Jenkins only.
 </div>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/mtslavescloud/templates/SlaveTemplate/configure.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/mtslavescloud/templates/SlaveTemplate/configure.jelly
@@ -22,6 +22,7 @@
   ~ THE SOFTWARE.
   -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout title="${%Configure} - ${it.displayName}" permission="${it.EXTENDED_READ}">
     <st:include page="sidepanel.jelly"/>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/mtslavescloud/templates/SlaveTemplate/index.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/mtslavescloud/templates/SlaveTemplate/index.jelly
@@ -22,6 +22,7 @@
   ~ THE SOFTWARE.
   -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout title="${it.displayName}" >
     <st:include page="sidepanel.jelly"/>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/mtslavescloud/templates/SlaveTemplate/sidepanel.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/mtslavescloud/templates/SlaveTemplate/sidepanel.jelly
@@ -22,6 +22,7 @@
   ~ THE SOFTWARE.
   -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:s="/lib/form">
   <l:side-panel>
     <l:tasks>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/mtslavescloud/templates/SlaveTemplateList/index.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/mtslavescloud/templates/SlaveTemplateList/index.jelly
@@ -22,6 +22,7 @@
   ~ THE SOFTWARE.
   -->
 
+<?jelly escape-by-default='true'?>
 <l:layout title="${%Templates}" xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
           xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <st:include page="sidepanel.jelly"/>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/mtslavescloud/templates/SlaveTemplateList/new.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/mtslavescloud/templates/SlaveTemplateList/new.jelly
@@ -25,6 +25,7 @@
 <!--
   Creates a new model.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:s="/lib/form">
   <l:layout title="${%Create a new slave template}" norefresh="true" permission="${it.CREATE}">
     <st:include page="sidepanel.jelly" />

--- a/src/main/resources/com/cloudbees/jenkins/plugins/mtslavescloud/templates/SlaveTemplateList/sidepanel.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/mtslavescloud/templates/SlaveTemplateList/sidepanel.jelly
@@ -22,6 +22,7 @@
   ~ THE SOFTWARE.
   -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:s="/lib/form">
   <l:header />
   <l:side-panel>

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -22,6 +22,7 @@
   ~ THE SOFTWARE.
   -->
 
+<?jelly escape-by-default='true'?>
 <div>
     This plugin provisions DEV@cloud slaves which boot and connect in seconds, and cache your workspace efficiently for future builds. 
     Both Linux and OSX slaves are available. This plugin requires a CloudBees account.


### PR DESCRIPTION
This NodeProvisioner takes advantages of recent API introduced in Jenkins
to replace the default node provisioner used by Jenkins for Cloud plugins.
It allows to kick off node provisioning as soon as a job is in the build
queue. The patch is heavily based on Stephen's work on OC.

To limit the load on mansion server, no more than 2 nodes can be
provisioned at a time. Provisioning is considered complete when Jenkins
is able to start a build on the node.

This fixes the slow provisioning sometimes encountered and also
hopefully overprovisioning situations encountered when Mansion can't
provision nodes fast enough. In my recent testing, I was able to get 5
nodes for 1 build in the queue. With this patch, I never had more than
2 nodes provisioning at the same time.

@reviewbybees esp @stephenc @imeredith @woohgit 